### PR TITLE
add: checklistテーブルに一意制約を追加

### DIFF
--- a/app/models/checklist.rb
+++ b/app/models/checklist.rb
@@ -1,5 +1,5 @@
 class Checklist < ApplicationRecord
-  validates :title, presence: true
+  validates :title, presence: true, uniqueness: true
 
   has_many :checklist_items, dependent: :destroy
   belongs_to :user

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,6 @@ module Myapp
     end
 
     config.i18n.default_locale = :ja
-    config.time_zone = 'Tokyo'
+    config.time_zone = "Tokyo"
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,5 +32,6 @@ module Myapp
     end
 
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
   end
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -14,15 +14,21 @@ ja:
         body: 購入理由
         purchase_date: 購入日
         price: 購入金額
-      category: 
-        name: カテゴリー
-      season: 
-        name: シーズン
+        season_ids: シーズン
+        category_ids: カテゴリー
       checklist:
-        title: チェックリスト
+        title: タイトル
       checklist_item:
         name: アイテム
+    errors:
+      models:
+        cloth:
+          blank: 必須項目です
+          less_than_or_equal_to: 明日以降の日付は入力できません
+        checklist:
+          taken: 既に登録されています
   attributes:
     id: ID
     created_at: 作成日時
     updated_at: 更新日時
+  

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -34,7 +34,7 @@ ja:
   season: 
     name: シーズン
   checklist:
-    title: チェックリスト
+    title: チェックリストタイトル
   checklist_item:
     name: アイテム
   header:

--- a/db/migrate/20250228081756_create_checklists.rb
+++ b/db/migrate/20250228081756_create_checklists.rb
@@ -6,5 +6,6 @@ class CreateChecklists < ActiveRecord::Migration[7.2]
 
       t.timestamps
     end
+    add_index :checklists, :title, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,6 +44,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_28_163026) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["title"], name: "index_checklists_on_title", unique: true
     t.index ["user_id"], name: "index_checklists_on_user_id"
   end
 


### PR DESCRIPTION
済

- checklistテーブル、titleカラムに一意制約を追加
→titleの重複はユーザーエクスペリエンスを削ぐため。
checklist_itemテーブルのnameカラムは重複を許すことで違うtitleでも同じアイテム名で作成できるようにする