### PR TITLE
fix: mvpリリース

### DIFF
--- a/app/views/checklists/edit.html.erb
+++ b/app/views/checklists/edit.html.erb
@@ -1,6 +1,6 @@
 <%= render "form" %>
 
-<div class="mt-6 text-center">
-  <%= link_to I18n.t(".defaults.show"), checklist_path %>
+<div class="text-center">
+  <%= link_to I18n.t(".helpers.submit.back"), checklist_path, class: "btn btn-link" %>
   <%= link_to I18n.t(".defaults.index"), checklists_path, class: "btn btn-link" %>
 </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,21 +1,10 @@
 <footer class="footer sm:footer-horizontal bg-neutral text-base-100 p-10">  <div class="container mx-auto flex flex-col md:flex-row justify-between items-center">
   <div class="container mx-auto flex justify-between items-center">
-  <div>
-    <img src="#" width="140" height="20" alt="WellDone Logo（未）" class="w-36" />
-  </div>
   <div class="grid grid-cols-2 gap-8 text-left">
     <div>
       <p class="font-bold text-lg">FOLLOW ME</p>
       <ul>
         <li><a href="https://github.com/kobakaho" class="link link-hover">GitHub</a></li>
-      </ul>
-    </div>
-    <div>
-      <p class="font-bold text-lg">ABOUT</p>
-      <ul>
-        <li><a href="#" class="link link-hover"><%= I18n.t(".fotter.contact_us") %></a></li>
-        <li><a href="#" class="link link-hover"><%= I18n.t(".fotter.terms_of_service") %></a></li>
-        <li><a href="#" class="link link-hover"><%= I18n.t(".fotter.privacy_policy") %></a></li>
       </ul>
     </div>
   </div>

--- a/app/views/static_pages/guide.html.erb
+++ b/app/views/static_pages/guide.html.erb
@@ -1,0 +1,107 @@
+<div class="mt-20 flex space-x-4">
+<!-- 画像1 -->
+<div class="max-w-sm rounded overflow-hidden shadow-lg">
+  <img class="w-full" src="../img/guide.JPG" alt="guide1">
+  <div class="px-6 py-4">
+    <div class="font-bold text-xl mb-2">使い方1</div>
+    <p class="text-gray-700 text-base">使い方1詳細</p>
+  </div>
+</div>
+<!-- 画像2 -->
+<div class="max-w-sm rounded overflow-hidden shadow-lg">
+  <img class="w-full" src="../img/guide.JPG" alt="guide2">
+  <div class="px-6 py-4">
+    <div class="font-bold text-xl mb-2">使い方2</div>
+    <p class="text-gray-700 text-base">使い方2詳細</p>
+  </div>
+</div>
+<!-- 画像3 -->
+<div class="max-w-sm rounded overflow-hidden shadow-lg">
+  <img class="w-full" src="../img/guide.JPG" alt="guide3">
+  <div class="px-6 py-4">
+    <div class="font-bold text-xl mb-2">使い方3</div>
+    <p class="text-gray-700 text-base">使い方3詳細</p>
+  </div>
+</div>
+<!-- 画像4 -->
+<div class="max-w-sm rounded overflow-hidden shadow-lg">
+  <img class="w-full" src="../img/guide.JPG" alt="guide4">
+  <div class="px-6 py-4">
+    <div class="font-bold text-xl mb-2">使い方4</div>
+    <p class="text-gray-700 text-base">使い方4詳細</p>
+  </div>
+</div>
+</div>
+<div class="mt-20 flex flex-wrap space-x-4">
+  <!-- 画像1 -->
+  <div class="max-w-sm rounded overflow-hidden shadow-lg">
+    <a href="https://gyazo.com/811ad342ebe3dc7252bf90d3074264b0">
+      <img src="https://i.gyazo.com/811ad342ebe3dc7252bf90d3074264b0.gif" alt="持っている服を登録する方法" width="702.67"/>
+    </a>
+    <div class="px-6 py-4">
+      <div class="font-bold text-xl mb-2">持っている服を登録しましょう！</div>
+      <p class="text-gray-700 text-base">服のカテゴリーとシーズンは必須項目です。任意の項目は覚えている範囲で入力しておきましょう。</p>
+    </div>
+  </div>
+
+  <!-- 画像2 -->
+  <div class="max-w-sm rounded overflow-hidden shadow-lg">
+    <a href="https://gyazo.com/9354d3ef49a1ebfc2425044f090ddddd">
+      <img src="https://i.gyazo.com/9354d3ef49a1ebfc2425044f090ddddd.png" alt="入力フォーム画面" width="317.33"/>
+    </a>
+    <div class="px-6 py-4">
+      <div class="font-bold text-xl mb-2">入力フォーム画面</div>
+      <p class="text-gray-700 text-base">フォームに必要な情報を入力してください。</p>
+    </div>
+  </div>
+
+  <!-- 画像3 -->
+  <div class="max-w-sm rounded overflow-hidden shadow-lg">
+    <a href="https://gyazo.com/3527b02d54b3a152d2c9262f2c0d704e">
+      <img src="https://i.gyazo.com/3527b02d54b3a152d2c9262f2c0d704e.png" alt="詳細画面" width="320.67"/>
+    </a>
+    <div class="px-6 py-4">
+      <div class="font-bold text-xl mb-2">詳細画面</div>
+      <p class="text-gray-700 text-base">登録した服の詳細情報を確認できます。</p>
+    </div>
+  </div>
+
+  <!-- 画像4 -->
+  <div class="max-w-sm rounded overflow-hidden shadow-lg">
+    <a href="https://gyazo.com/ae3456114ef494512ce52633ce4bde11">
+      <img src="https://i.gyazo.com/ae3456114ef494512ce52633ce4bde11.png" alt="チェックリストの活用" width="702.67"/>
+    </a>
+    <div class="px-6 py-4">
+      <div class="font-bold text-xl mb-2">使い方4</div>
+      <p class="text-gray-700 text-base">チェックリストを活用して、断捨離のタイミングを管理しましょう。</p>
+    </div>
+  </div>
+</div>
+
+
+<footer class="footer sm:footer-horizontal bg-neutral text-base-100 p-10">  <div class="container mx-auto flex flex-col md:flex-row justify-between items-center">
+  <div class="container mx-auto flex justify-between items-center">
+  <div>
+    <img src="#" width="140" height="20" alt="WellDone Logo（未）" class="w-36" />
+  </div>
+  <div class="grid grid-cols-2 gap-8 text-left">
+    <div>
+      <p class="font-bold text-lg">FOLLOW ME</p>
+      <ul>
+        <li><a href="https://github.com/kobakaho" class="link link-hover">GitHub</a></li>
+      </ul>
+    </div>
+    <div>
+      <p class="font-bold text-lg">ABOUT</p>
+      <ul>
+        <li><a href="#" class="link link-hover"><%= I18n.t(".fotter.contact_us") %></a></li>
+        <li><a href="#" class="link link-hover"><%= I18n.t(".fotter.terms_of_service") %></a></li>
+        <li><a href="#" class="link link-hover"><%= I18n.t(".fotter.privacy_policy") %></a></li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="divider my-4"></div>
+
+  <p class="text-center text-sm opacity-80">© 2025 - WellDone</p>
+</footer>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,43 +1,6 @@
 <div class="p-4 flex items-center justify-center h-screen text-center">
   <div>
-    <h1 class="text-8xl font-bold">well断</h1>
+    <h1 class="text-9xl font-bold">well断</h1>
     <h2 class="mt-10">クローゼット管理と断捨離のアプリ</h2>
-    
-    <!--ガイド slider導入 -->
-      
-    <div class="mt-20 flex space-x-4">
-      <!-- 画像1 -->
-      <div class="max-w-sm rounded overflow-hidden shadow-lg">
-        <img class="w-full" src="../img/guide.JPG" alt="guide1">
-        <div class="px-6 py-4">
-          <div class="font-bold text-xl mb-2">使い方1</div>
-          <p class="text-gray-700 text-base">使い方1詳細</p>
-        </div>
-      </div>
-      <!-- 画像2 -->
-      <div class="max-w-sm rounded overflow-hidden shadow-lg">
-        <img class="w-full" src="../img/guide.JPG" alt="guide2">
-        <div class="px-6 py-4">
-          <div class="font-bold text-xl mb-2">使い方2</div>
-          <p class="text-gray-700 text-base">使い方2詳細</p>
-        </div>
-      </div>
-      <!-- 画像3 -->
-      <div class="max-w-sm rounded overflow-hidden shadow-lg">
-        <img class="w-full" src="../img/guide.JPG" alt="guide3">
-        <div class="px-6 py-4">
-          <div class="font-bold text-xl mb-2">使い方3</div>
-          <p class="text-gray-700 text-base">使い方3詳細</p>
-        </div>
-      </div>
-      <!-- 画像4 -->
-      <div class="max-w-sm rounded overflow-hidden shadow-lg">
-        <img class="w-full" src="../img/guide.JPG" alt="guide4">
-        <div class="px-6 py-4">
-          <div class="font-bold text-xl mb-2">使い方4</div>
-          <p class="text-gray-700 text-base">使い方4詳細</p>
-        </div>
-      </div>
-    </div>
   </div>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -40,7 +40,7 @@ ja:
   header:
     closet: クローゼット
     profile: プロフィール
-    checklist: チェックリスト
+    checklist: 断捨離チェックリスト
   fotter:
     contact_us: お問い合わせ
     terms_of_service: 利用規約


### PR DESCRIPTION
- MVPリリースのため未実装箇所を他ファイルに保存
> top画面のガイド、footerのABOUT

google認証のステータスを「公開」に変更
ブラウザでの使用のみ許可しているため携帯からのログインは現在（2025年3月19日）不可