### PR TITLE
fix: seed.rb修正

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,18 +18,91 @@ end
 # チェックリストに合わせて要修正
 Category.delete_all
 
-root = Category.create!(name: '服、アイテム')
+# 1階層
+wear = Category.find_or_create_by!(name: '着るもの')
+accessary = Category.find_or_create_by!(name: '身に着けるもの')
 
-wear = root.children.create!(name: '着るもの')
-accessary = root.children.create!(name: '身に着けるもの')
+# 2階層（着るもの）
+tops = wear.children.find_or_create_by!(name: 'トップス')
+outer = wear.children.find_or_create_by!(name: 'アウター')
+pants = wear.children.find_or_create_by!(name: 'パンツ')
+skirt = wear.children.find_or_create_by!(name: 'スカート')
+onepiece = wear.children.find_or_create_by!(name: 'ワンピース / オールインワン')
+other = wear.children.find_or_create_by!(name: 'その他')
 
-wear.children.create!(name: 'トップス')
-wear.children.create!(name: 'アウター')
-wear.children.create!(name: 'パンツ')
-wear.children.create!(name: 'スカート')
-wear.children.create!(name: 'ワンピース / オールインワン')
-accessary.children.create!(name: '帽子')
-accessary.children.create!(name: 'バッグ')
-accessary.children.create!(name: 'シューズ')
-accessary.children.create!(name: 'アンダーウェア')
-accessary.children.create!(name: 'ファッション小物')
+# 3階層（トップスの子カテゴリ）
+tops.children.find_or_create_by!(name: 'Tシャツ/カットソー')
+tops.children.find_or_create_by!(name: 'シャツ/ブラウス')
+tops.children.find_or_create_by!(name: 'ベスト')
+tops.children.find_or_create_by!(name: 'シャツ/パーカー')
+tops.children.find_or_create_by!(name: 'ニット / セーター')
+tops.children.find_or_create_by!(name: 'その他トップス')
+
+
+# 3階層（アウターの子カテゴリ）
+outer.children.find_or_create_by!(name: 'ジャケット')
+outer.children.find_or_create_by!(name: 'コート')
+outer.children.find_or_create_by!(name: 'ブルゾン')
+outer.children.find_or_create_by!(name: 'その他アウター')
+
+# 3階層（パンツの子カテゴリ）
+pants.children.find_or_create_by!(name: 'デニム')
+pants.children.find_or_create_by!(name: 'スラックス')
+pants.children.find_or_create_by!(name: 'ショートパンツ')
+pants.children.find_or_create_by!(name: 'その他パンツ')
+
+# 3階層（スカートの子カテゴリ）
+skirt.children.find_or_create_by!(name: 'ロングスカート')
+skirt.children.find_or_create_by!(name: 'ミニスカート')
+skirt.children.find_or_create_by!(name: 'その他スカート')
+
+onepiece.children.find_or_create_by!(name: 'ワンピース')
+onepiece.children.find_or_create_by!(name: 'シャツワンピース')
+onepiece.children.find_or_create_by!(name: 'ジャンパースカート')
+onepiece.children.find_or_create_by!(name: 'サロペット/オーバーオール')
+onepiece.children.find_or_create_by!(name: 'その他ワンピース / オールインワン')
+
+
+# 3階層（アンダーウェアの子カテゴリ）
+
+# 2階層（身に着けるもの）
+hat = accessary.children.find_or_create_by!(name: '帽子')
+bag = accessary.children.find_or_create_by!(name: 'バッグ')
+shoes = accessary.children.find_or_create_by!(name: 'シューズ')
+small_item = accessary.children.find_or_create_by!(name: 'ファッション小物')
+other = accessary.children.find_or_create_by!(name: 'その他')
+
+# 3階層（帽子）
+hat.children.find_or_create_by!(name: 'キャップ')
+hat.children.find_or_create_by!(name: 'ハット')
+hat.children.find_or_create_by!(name: 'ベレー帽')
+hat.children.find_or_create_by!(name: 'その他帽子')
+
+# 3階層（バッグ）
+bag.children.find_or_create_by!(name: 'トートバッグ')
+bag.children.find_or_create_by!(name: 'リュック')
+bag.children.find_or_create_by!(name: 'ショルダーバッグ')
+bag.children.find_or_create_by!(name: 'ハンドバック')
+bag.children.find_or_create_by!(name: 'クラッチバック')
+bag.children.find_or_create_by!(name: 'ショルダーバッグ')
+bag.children.find_or_create_by!(name: 'かごバック')
+bag.children.find_or_create_by!(name: 'その他バック')
+
+
+# 3階層（シューズ）
+shoes.children.find_or_create_by!(name: 'スニーカー')
+shoes.children.find_or_create_by!(name: 'パンプス')
+shoes.children.find_or_create_by!(name: 'サンダル')
+shoes.children.find_or_create_by!(name: 'バレエシューズ')
+shoes.children.find_or_create_by!(name: 'ローファー')
+shoes.children.find_or_create_by!(name: 'ブーツ')
+shoes.children.find_or_create_by!(name: 'その他シューズ')
+
+# 3階層（ファッション小物）
+small_item.children.find_or_create_by!(name: 'アクセサリー')
+small_item.children.find_or_create_by!(name: 'ヘアアクセサー')
+small_item.children.find_or_create_by!(name: 'サングラス')
+small_item.children.find_or_create_by!(name: '時計')
+small_item.children.find_or_create_by!(name: 'ベルト')
+small_item.children.find_or_create_by!(name: 'マフラー')
+small_item.children.find_or_create_by!(name: 'その他ファッション小物')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,6 +16,7 @@ end
 
 
 # チェックリストに合わせて要修正
+CategoryCloth.delete_all
 Category.delete_all
 
 # 1階層


### PR DESCRIPTION
理由：cloth入力フォームのカテゴリー項目が少なかったため、ユーザーが選択できる項目の幅をできるだけ増やしUXを向上させるため


済

- seed.rb/`CategoryCloth.delete_all`　を追加し外部キーで参照されているテーブルからもレコードを削除できるようにした
- `find_or_create_by!`を使い、重複するレコードが作成されないようにした

結果

- 開発環境＆本番環境ともにカテゴリーの初期データを更新！
- 一階層目を”服・アイテム”から”着るもの””身に着けるもの”に変更
- 三階層目は二階層目が細分化される項目に変更
[![Image from Gyazo](https://i.gyazo.com/5dc40d093324854f3b7f8d5d4a271ee0.png)](https://gyazo.com/5dc40d093324854f3b7f8d5d4a271ee0)