### PR TITLE
add:  ローディングアニメーション

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,5 +10,8 @@ application.register("category", CategoryController)
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 
+import LoadingController from "./loading_controller"
+application.register("loading", LoadingController)
+
 import ModalController from "./modal_controller"
 application.register("modal", ModalController)

--- a/app/javascript/controllers/loading_controller.js
+++ b/app/javascript/controllers/loading_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="loading"
+export default class extends Controller {
+  static targets = ["spinner"]
+
+  connect() {
+    console.log("loading.js 読み込みに成功しました")
+    this.hide()
+  }
+  show() {
+    this.spinnerTarget.classList.remove("hidden")
+  }
+  hide() {
+    this.spinnerTarget.classList.add("hidden")
+    //リロードして閉じる 現状画面遷移までの間で閉じる
+  }
+}

--- a/app/javascript/controllers/loading_controller.js
+++ b/app/javascript/controllers/loading_controller.js
@@ -13,6 +13,5 @@ export default class extends Controller {
   }
   hide() {
     this.spinnerTarget.classList.add("hidden")
-    //リロードして閉じる 現状画面遷移までの間で閉じる
   }
 }

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -8,7 +8,6 @@ export default class extends Controller {
     this.dialog = this.dialogTarget
     console.log("modal.js 読み込みに成功しました")
   }
-
   open(event) {
     event.preventDefault()
     this.dialog.showModal()
@@ -22,6 +21,9 @@ export default class extends Controller {
   closeOnSubmit(event) {
     if (event.detail.success) {
       this.dialog.close()
+      setTimeout(() => {
+        location.reload();
+      }, 1);
     }
   }
 

--- a/app/views/checklists/_checklist.html.erb
+++ b/app/views/checklists/_checklist.html.erb
@@ -1,0 +1,2 @@
+<div class="font-semibold text-center"><%= checklist.title %></div>
+

--- a/app/views/checklists/_form.html.erb
+++ b/app/views/checklists/_form.html.erb
@@ -6,6 +6,6 @@
   </div>
 
   <div class="mt-6 text-center">
-    <%= form.submit I18n.t(".helpers.submit.submit"), class: "btn btn-primary" %>
+    <%= form.submit I18n.t(".helpers.submit.submit"), data: { action: "click->loading#show" }, class: "btn btn-primary" %>
   </div>
 <% end %>

--- a/app/views/checklists/index.html.erb
+++ b/app/views/checklists/index.html.erb
@@ -1,9 +1,8 @@
 <div class="container mx-auto p-4 min-h-screen flex flex-col">
 
-  <p class="text-center mt-4 text-sm text-gray-500">画面を最新の状態にするにはリロードしてください</p>
-    <%= link_to new_checklist_path, data: { action: "modal#open", turbo_frame: "modal" } do %>
-      <button class="btn btn-circle fa-solid fa-plus fa-2xl" style="color: #293454;"></button>
-    <% end %>絶対位置
+  <%= link_to new_checklist_path, data: { action: "modal#open", turbo_frame: "modal" } do %>
+    <button class="btn btn-circle fa-solid fa-plus fa-2xl" style="color: #293454;"></button>
+  <% end %>絶対位置
 
   <div id="new_checklist" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3">
     <% if @checklists.present? %>

--- a/app/views/cloths/_form.html.erb
+++ b/app/views/cloths/_form.html.erb
@@ -74,6 +74,6 @@
   </div>
   
   <div>
-    <%= form.submit I18n.t(".helpers.submit.submit"), class: "btn btn-primary btn-block mt-6" %>
+    <%= form.submit I18n.t(".helpers.submit.submit"), data: { action: "click->loading#show" }, class: "btn btn-primary btn-block mt-6" %>
   </div>
 <% end %>

--- a/app/views/cloths/index.html.erb
+++ b/app/views/cloths/index.html.erb
@@ -5,28 +5,24 @@
   </aside>
 
   <main class="flex-1 p-4">
-    <p class="text-center mt-4 text-sm text-gray-500">画面を最新の状態にするにはリロードしてください</p>
 
-    <%= link_to new_cloth_path, data: { action: "modal#open", turbo_frame: "modal" } do %>
-      <button class="btn  btn-circle fa-solid fa-plus fa-2xl" style="color: #293454;"></button>
-    <% end %>
+  <%= link_to new_cloth_path, data: { action: "modal#open", turbo_frame: "modal" } do %>
+    <button class="btn  btn-circle fa-solid fa-plus fa-2xl" style="color: #293454;"></button>
+  <% end %>
 
-    <div id="new_cloth">
-      <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-3 gap-6 my-8">
-        <% if @cloths.present? %>
-          <% @cloths.each do |cloth| %>
-            <%= link_to cloth_path(cloth), class: "block bg-base-100  rounded-md overflow-hidden transition-transform transform hover:scale-105" do %>
-              <div class="w-full aspect-square">
-                <%= image_tag cloth.image_file.url, class: "w-full h-full object-cover" %>
-              </div>
-            <% end %>
-          <% end %>
-        <% else %>
-          <div class="text-center mt-4">アイテムが見つかりませんでした</div>
+  <div id="new_cloth" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-3 gap-6 my-8">
+    <% if @cloths.present? %>
+      <% @cloths.each do |cloth| %>
+        <%= link_to cloth_path(cloth), class: "block bg-base-100  rounded-md overflow-hidden transition-transform transform hover:scale-105" do %>
+          <div class="w-full aspect-square">
+            <%= image_tag cloth.image_file.url, class: "w-full h-full object-cover" %>
+          </div>
         <% end %>
-      </div>     
-    </div>
-    <%= paginate @cloths %>
-
+      <% end %>
+    <% else %>
+      <div class="text-center mt-4">アイテムが見つかりませんでした</div>
+    <% end %>
+  </div>     
+  <%= paginate @cloths %>
   </main>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,10 +31,7 @@
     </script>
   </head>
 
-  <body>
-    <div class="container">
-      <div class="hero-overlay bg-base-100">
-
+  <body class="flex flex-col min-h-screean bg-base-100">
         <% if flash[:notice].present? %>
           <div class="alert alert-success flex items-center">
             <svg
@@ -68,17 +65,23 @@
             <span><%= flash[:alert] %></span>
           </div>
         <% end %>
+
+        <div data-controller="loading">
+          <div data-loading-target="spinner" class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40 hidden">
+            <div class="h-[150px] w-[150px] flex items-center justify-center">
+              <span class="loading loading-dots loading-lg"></span>
+            </div>
+          </div>
     
-        <% if user_signed_in? %>
-        <%= render "shared/header" %>
-        <% else %>
-        <%= render "shared/before_sign_in_header" %>
-        <% end %>
-        <%= yield %>
-        <%= turbo_frame_tag "modal" %>
-        <%= render 'shared/footer'%>
-      </div>
-    </div>
+          <% if user_signed_in? %>
+          <%= render "shared/header" %>
+          <% else %>
+          <%= render "shared/before_sign_in_header" %>
+          <% end %>
+          <%= yield %>
+          <%= turbo_frame_tag "modal" %>
+          <%= render 'shared/footer'%>
+        <div>
   </body>
 </html>
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -19,7 +19,7 @@
         </label>
       </div>
       <div class="mx-2 flex-1 px-2">
-        <%= link_to "/", class: "btn btn-ghost" do %>
+        <%= link_to "/", class: "btn btn-ghost", data: { action: "click->loading#show" } do %>
           <%= image_tag "logo.png", width: 140, height: 20, class: "w-20" %>
         <% end %>
       </div>
@@ -28,14 +28,14 @@
 
           <li>
           <details>
-            <summary><%= link_to I18n.t(".header.closet"), cloths_path, class: "btn btn-ghost" %></summary>
+            <summary><%= link_to I18n.t(".header.closet"), cloths_path, data: { action: "click->loading#show" }, class: "btn btn-ghost" %></summary>
             <ul class="p-2">
-              <li><%= link_to "わたしのお気に入り", favorites_cloths_path, class: "btn btn btn-ghost" %></li>
-              <li><%= link_to "みんなの断捨離タイムライン", discarded_cloths_path, class: "btn btn btn-ghost" %></li>
+              <li><%= link_to "わたしのお気に入り", favorites_cloths_path, data: { action: "click->loading#show" }, class: "btn btn btn-ghost" %></li>
+              <li><%= link_to "みんなの断捨離タイムライン", discarded_cloths_path, data: { action: "click->loading#show" }, class: "btn btn btn-ghost" %></li>
             </ul>
           </details>
           </li>
-          <li><%= link_to I18n.t(".header.checklist"), checklists_path, class: "btn btn-ghost" %></li>
+          <li><%= link_to I18n.t(".header.checklist"), checklists_path, data: { action: "click->loading#show" }, class: "btn btn-ghost" %></li>
           <% if current_user %>
             <div class="dropdown dropdown-end">
               <div tabindex="0" role="button" class="btn btn-ghost btn-circle avatar">
@@ -76,14 +76,14 @@
       </div>
       <li>
       <details>
-        <summary><%= link_to I18n.t(".header.closet"), cloths_path, class: "btn btn-ghost" %></summary>
+        <summary><%= link_to I18n.t(".header.closet"), cloths_path, data: { action: "click->loading#show" }, class: "btn btn-ghost" %></summary>
         <ul class="p-2">
-          <li><%= link_to "わたしのお気に入り", favorites_cloths_path, class: "btn btn btn-ghost" %></li>
-          <li><%= link_to "みんなの断捨離タイムライン", discarded_cloths_path, class: "btn btn btn-ghost" %></li>
+          <li><%= link_to "わたしのお気に入り", favorites_cloths_path, data: { action: "click->loading#show" }, class: "btn btn btn-ghost" %></li>
+          <li><%= link_to "みんなの断捨離タイムライン", discarded_cloths_path, data: { action: "click->loading#show" }, class: "btn btn btn-ghost" %></li>
         </ul>
       </details>
       </li>
-      <li><%= link_to I18n.t(".header.checklist"), checklists_path, class: "btn btn-ghost" %></li>
+      <li><%= link_to I18n.t(".header.checklist"), checklists_path, data: { action: "click->loading#show" }, class: "btn btn-ghost" %></li>
     </ul>
   </div>
 </header>


### PR DESCRIPTION
済

- stimulusでローディングアニメーションを実装
- ヘッダーから遷移先をクリック時にJSが動く
- clothとchecklistのsubmitボタンを押したときにloadingが開く
- 画面遷移またはリロードしたらloadingが閉じる

参考記事：　[Stimulusで簡単！daisyUIとRailsを使ったローディングアニメーション演出
](https://zenn.dev/hisa_dev/articles/4050eb4b658678#terminal)
これまでの課題

- modalで表示させた入力フォームのsubmitが成功してindexに非同期表示させたとき、リロードしないとindex.htmlで指定したクラスが反映されない

> 画面遷移またはリロードしたらloadingが閉じる

ということは、強制的にリロードを実行すればloadingも閉じるしindex.htmlで指定したクラスも反映されるのでは
→issue/ ページ全体をajax更新する　が違う方法で解決＾＾

 ```
 closeOnSubmit(event) {
    if (event.detail.success) {
      this.dialog.close()
追記      setTimeout(() => {   
追記        location.reload();
追記      }, 1);  
    }
```

[![Image from Gyazo](https://i.gyazo.com/2f53c0f9c52b6194b60c2528329ae0fa.gif)](https://gyazo.com/2f53c0f9c52b6194b60c2528329ae0fa)
