### PR TITLE
improve:  見た目修正

### DIFF
--- a/app/controllers/cloths_controller.rb
+++ b/app/controllers/cloths_controller.rb
@@ -63,7 +63,7 @@ class ClothsController < ApplicationController
   end
 
   def discarded
-    @discarded_cloths = Cloth.includes(:user).discarded
+    @discarded_cloths = Cloth.includes(:user).discarded.order(discarded_at: :asc)
   end
 
   def destroy_discarded

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
-  # before_action :configure_sign_up_params, only: [:create]
+  before_action :configure_sign_up_params, only: [ :create ]
   before_action :configure_account_update_params, only: [ :update ]
 
   # GET /resource/sign_up
@@ -51,9 +51,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # protected
 
   # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
-  # end
+  def configure_sign_up_params
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :username ])
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   def configure_account_update_params

--- a/app/views/checklists/index.html.erb
+++ b/app/views/checklists/index.html.erb
@@ -1,10 +1,10 @@
 <div class="container mx-auto p-4 flex flex-wrap min-h-screen flex flex-col">
 
   <%= link_to new_checklist_path, data: { action: "modal#open", turbo_frame: "modal" } do %>
-    <button class="btn btn-circle fa-solid fa-plus fa-2xl" style="color: #293454;"></button>
+    <button class=" btn btn-block fa-solid fa-plus fa-2xl" style="color: #293454;"></button>
   <% end %>
 
-  <div id="new_checklist" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3">
+  <div id="new_checklist" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 mt-3">
     <% if @checklists.present? %>
       <% @checklists.each do |checklist| %>
 
@@ -23,10 +23,8 @@
                   <% end %>
           
                   <%= link_to checklist, data: { turbo_method: :delete, confirm: "本当に削除しますか？作成したアイテムも削除されます", turbo_confirm: "本当に削除しますか？作成したアイテムも削除されます" } do %>
-                    <div class="tooltip" data-tip="削除">
-                      <button class="btn btn-circle fa-solid fa-trash fa-lg" style="color: #293454;" ></button>
-                    </div>
-                    <% end %>
+                    <button class="btn btn-circle fa-solid fa-trash fa-lg" style="color: #293454;" ></button>
+                  <% end %>
                 </div>
             </div>
           </div>

--- a/app/views/checklists/show.html.erb
+++ b/app/views/checklists/show.html.erb
@@ -4,10 +4,8 @@
     <div class="flex justify-between items-center">
 
       <%= link_to checklists_path do %>
-        <div class="tooltip" data-tip="戻る">
-          <button class="btn btn-ghost btn-circle fa-solid fa-arrow-right fa-rotate-180 fa-xl" style="color: #293454;"></button>
-        </div>
-        <% end %>
+        <button class="btn btn-ghost btn-circle fa-solid fa-arrow-right fa-rotate-180 fa-xl" style="color: #293454;"></button>
+      <% end %>
       <h1 class="text-xl font-bold text-center"><%= @checklist.title %></h1>
 
       <%= link_to new_checklist_item_path(@checklist) do %>

--- a/app/views/cloths/_favorite.html.erb
+++ b/app/views/cloths/_favorite.html.erb
@@ -1,5 +1,3 @@
 <%= link_to favorites_path(cloth_id: cloth.id), id: "favorite-button-for-cloth-#{cloth.id}", data: { turbo_method: :post } do %>
-  <div class="tooltip" data-tip="お気に入り"> 
-    <button class="btn btn-ghost fa-regular fa-heart fa-xl" style="color: #bb6c69;"></button>
-  </div>
+  <button class="btn btn-ghost fa-regular fa-heart fa-xl" style="color: #bb6c69;"></button>
 <% end %>

--- a/app/views/cloths/_search_form.html.erb
+++ b/app/views/cloths/_search_form.html.erb
@@ -1,7 +1,7 @@
 <%= search_form_for q, url: url do |f| %>
 
   <div class="flex flex-col space-y-5">
-    <div class="font-bold text-center">検索フォーム</div>
+    <div class="font-bold text-center">検索</div>
 
     <%= f.select :categories_id_eq, options_for_select(Category.all.pluck(:name, :id)), { include_blank: "カテゴリーを選択" }, { class: "select select-bordered" } %>
 

--- a/app/views/cloths/_unfavorite.html.erb
+++ b/app/views/cloths/_unfavorite.html.erb
@@ -1,5 +1,3 @@
 <%= link_to favorite_path(current_user.favorites.find_by(cloth_id: cloth.id)), id: "unfavorite-button-for-cloth-#{cloth.id}", data: { turbo_method: :delete } do %>
-  <div class="tooltip" data-tip="お気に入りからはずす"> 
-    <button class="btn btn-ghost fa-solid fa-heart fa-xl" style="color: #bb6c69;"></button>
-  </div>
+  <button class="btn btn-ghost fa-solid fa-heart fa-xl" style="color: #bb6c69;"></button>
 <% end %>

--- a/app/views/cloths/discarded.html.erb
+++ b/app/views/cloths/discarded.html.erb
@@ -18,21 +18,22 @@
             </div>
 
             <div class="timeline-end timeline-box flex items-center space-x-4 p-4">
-              <div class="flex w-full flex-col">
+              <div class="flex flex-col">
+                <div class="flex items-center gap-3">
                 <div class="avatar">
-                  <div class="w-12 rounded-full">
+                  <div class="w-10 rounded-full">
                     <%= image_tag cloth.user.profile_image_url %>
                   </div>
                 </div>
                 <div class="flex-1">
                   <p class="text-sm font-semibold"><%= cloth.user.username %> さんが断捨離しました！</p>
                 </div>
+                </div>
 
                 <% if user_signed_in? && cloth.user == current_user %>
                   <div class="divider"></div>
                   <div class="flex flex-wrap items-center justify-center space-x-2">
-                    <%= link_to "https://twitter.com/intent/tweet?text=well断で断捨離した！%0A&url=https://welldoneshari.com/cloths/discarded", 
-                                target: "_blank", rel: "noopener noreferrer" do %>
+                    <%= link_to "https://twitter.com/intent/tweet?text=well断で断捨離した！%0A&url=https://welldoneshari.com/cloths/discarded", target: "_blank", rel: "noopener noreferrer" do %>
                       <button class="btn btn-circle fa-brands fa-square-x-twitter fa-xl" style="color: #293454;"></button>
                     <% end %>
 

--- a/app/views/cloths/discarded.html.erb
+++ b/app/views/cloths/discarded.html.erb
@@ -1,49 +1,54 @@
-<div class="container mx-auto px-4 h-screen">
+<div class="container mx-auto px-4 h-full mb-10">
   <% if @discarded_cloths.present? %>
+    <% grouped_cloths = @discarded_cloths.group_by { |cloth| cloth.discarded_at.to_date.strftime("%m/%d") } %>
 
-  <ul class="timeline timeline-vertical ">
+    <ul class="timeline timeline-vertical">
+      <% grouped_cloths.each do |date, cloths| %>
+        <div class="divider mx-15"><%= date %></div>
 
-    <% @discarded_cloths.each do |cloth| %>
-      <li id="timeline-cloth-<%= cloth.id %>">
-        <div class="timeline-start">
-          <%= l(cloth.discarded_at, format: :short) %>
-        </div>
-        <div class="timeline-middle">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-5 w-5">
-          <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd" />
-          </svg>
-        </div>
-        <div class="timeline-end timeline-box flex items-center space-x-4 p-4">
-          <div class="flex w-full flex-col">
-            <div class="avatar">
-              <div class="w-12 rounded-full">
-                <%= image_tag cloth.user.profile_image_url %>
+        <% cloths.each do |cloth| %>
+          <li id="timeline-cloth-<%= cloth.id %>">
+            <div class="timeline-start">
+              <%= cloth.discarded_at.to_time.strftime("%H:%M") %>
+            </div>
+            <div class="timeline-middle">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-5 w-5">
+                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd" />
+              </svg>
+            </div>
+
+            <div class="timeline-end timeline-box flex items-center space-x-4 p-4">
+              <div class="flex w-full flex-col">
+                <div class="avatar">
+                  <div class="w-12 rounded-full">
+                    <%= image_tag cloth.user.profile_image_url %>
+                  </div>
+                </div>
+                <div class="flex-1">
+                  <p class="text-sm font-semibold"><%= cloth.user.username %> さんが断捨離しました！</p>
+                </div>
+
+                <% if user_signed_in? && cloth.user == current_user %>
+                  <div class="divider"></div>
+                  <div class="flex flex-wrap items-center justify-center space-x-2">
+                    <%= link_to "https://twitter.com/intent/tweet?text=well断で断捨離した！%0A&url=https://welldoneshari.com/cloths/discarded", 
+                                target: "_blank", rel: "noopener noreferrer" do %>
+                      <button class="btn btn-circle fa-brands fa-square-x-twitter fa-xl" style="color: #293454;"></button>
+                    <% end %>
+
+                    <%= link_to destroy_discarded_cloth_path(cloth, cloth.id, id: cloth), 
+                                data: { turbo_method: :delete, confirm: "本当に削除しますか？" } do %>
+                      <button class="btn btn-circle fa-solid fa-trash fa-lg" style="color: #293454;"></button>
+                    <% end %>
+                  </div>
+                <% end %>
               </div>
             </div>
-            <div class="flex-1">
-              <p class="text-sm font-semibold"><%= cloth.user.username %> さんが断捨離しました！！</p>
-            </div>
-            <% if user_signed_in? && cloth.user == current_user %>
-            <div class="divider"></div>
-
-            <div class="flex flex-wrap items-center flex justify-center space-x-2">
-
-              <%= link_to "https://twitter.com/intent/tweet?text=well断で断捨離した！%0A&url=https://welldoneshari.com/cloths/discarded", 
-              target: "_blank", rel: "noopener noreferrer" do %>
-                <button class="btn btn-circle fa-brands fa-square-x-twitter fa-xl" style="color: #293454;"></button>
-              <% end %>
-
-              <%= link_to destroy_discarded_cloth_path(cloth, cloth.id, id: cloth), data: { turbo_method: :delete, confirm: "本当に削除しますか？", turbo_confirm: "本当に削除しますか？" } do %>
-                <button class="btn btn-circle fa-solid fa-trash fa-lg" style="color: #293454;"></button>
-              <% end %>
-            </div>
-          <% end %>
-        </div>
-      </div>
-      <hr />
-      </li>
-    <% end %>
-  </ul>
+            <hr />
+          </li>
+        <% end %>
+      <% end %>
+    </ul>
   <% else %>
     <p>断捨離したアイテムはありません。</p>
   <% end %>

--- a/app/views/cloths/index.html.erb
+++ b/app/views/cloths/index.html.erb
@@ -7,7 +7,7 @@
   <main class="flex-1 p-4">
 
   <%= link_to new_cloth_path, data: { action: "modal#open", turbo_frame: "modal" } do %>
-    <button class="btn  btn-circle fa-solid fa-plus fa-2xl" style="color: #293454;"></button>
+    <button class=" btn btn-block fa-solid fa-plus fa-2xl" style="color: #293454;"></button>
   <% end %>
 
   <div id="new_cloth" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-3 lg:grid-cols-3 gap-6 my-8">

--- a/app/views/cloths/show.html.erb
+++ b/app/views/cloths/show.html.erb
@@ -2,23 +2,17 @@
   <div class="card bg-base-100 shadow-md w-96 relative p-6 my-6">
 
     <%= link_to cloths_path do %>
-      <div class="tooltip" data-tip="戻る"> 
-        <button class="btn btn-ghost btn-circle fa-solid fa-arrow-right fa-rotate-180 fa-2xl" style="color: #293454;" ></button>
-      </div>
-      <% end %>
+      <button class="btn btn-ghost btn-circle fa-solid fa-arrow-right fa-rotate-180 fa-2xl" style="color: #293454;" ></button>
+    <% end %>
 
     <div class="absolute right-4 space-x-2">
       <%= link_to edit_cloth_path(@cloth), data: { action: "modal#open", turbo_frame: "modal" } do %>
-        <div class="tooltip" data-tip="編集"> 
-          <button class="btn btn-circle fa-solid fa-pen-to-square fa-lg" style="color: #293454;" ></button>
-        </div>
-        <% end %>
+        <button class="btn btn-circle fa-solid fa-pen-to-square fa-lg" style="color: #293454;" ></button>
+      <% end %>
     
       <%= link_to @cloth, data: { turbo_method: :delete, confirm: "本当に削除しますか？", turbo_confirm: "本当に削除しますか？" } do %>
-        <div class="tooltip" data-tip="削除"> 
-          <button class="btn btn-circle fa-solid fa-trash fa-lg" style="color: #293454;"></button>
-        </div>
-        <% end %>
+        <button class="btn btn-circle fa-solid fa-trash fa-lg" style="color: #293454;"></button>
+      <% end %>
     </div>
 
     <%= render @cloth %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -2,9 +2,7 @@
   <div class="card bg-base-100 shadow-md w-96 relative p-6 my-5">
 
     <%= link_to :back do %>
-      <div class="tooltip" data-tip="戻る"> 
-        <button class="btn btn-ghost btn-circle fa-solid fa-arrow-right fa-rotate-180 fa-2xl" style="color: #293454;" ></button>
-      </div>
+      <button class="btn btn-ghost btn-circle fa-solid fa-arrow-right fa-rotate-180 fa-2xl" style="color: #293454;" ></button>
     <% end %>
 
     <div class="card-body">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -39,14 +39,12 @@
       <% end %>
       </div>
 
-      <div class="form-group mt-3">
+      <div class="form-group my-3">
         <%= f.submit t(".update"), class: "btn btn-primary w-full" %>
       </div>
       <% end %>
 
-      <h3 class="text-lg font-semibold mt-8"><%= t(".cancel_my_account") %>
-        <%= button_to t(".cancel_my_account"), registration_path(resource_name), data: { confirm: "本当に削除しますか？", turbo_confirm: "本当に削除しますか？" }, method: :delete, class: "btn btn-danger w-full" %>
-      </h3>
+      <%= button_to t(".cancel_my_account"), registration_path(resource_name), data: { confirm: "本当に削除しますか？", turbo_confirm: "本当に削除しますか？" }, method: :delete, class: "btn btn-ghost w-full" %>
     </div>
   </div>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -6,6 +6,12 @@
       
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
+        
+        <div>
+          <label class="input input-bordered flex items-center gap-2 mb-4">
+            <%= f.text_field :username, placeholder: "ユーザーネーム" %>
+          </label>
+        </div>
 
         <div>
           <label class="input input-bordered validator flex items-center gap-2">

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -2,11 +2,11 @@
   <div class="flex flex-col gap-3 md:flex-row bg-base-100 p-6 rounded-lg shadow-md">
 
     <aside class="w-full md:w-1/3 lg:w-1/3">
-      <%= link_to checklist_path(@checklist) do %>
-        <div class="tooltip" data-tip="戻る">
+      <div class="mb-5">
+        <%= link_to checklist_path(@checklist) do %>
           <button class="btn btn-ghost btn-circle fa-solid fa-arrow-right fa-rotate-180 fa-2xl" style="color: #293454;"></button>
-        </div>
         <% end %>
+      </div>
 
       <%= form_with model: @new_original_item, url: checklist_items_path(@checklist), class: "join w-full", local: true do |f| %>
         <%= render 'shared/error_messages', object: f.object %>
@@ -36,7 +36,7 @@
       </div>
     </aside>
 
-    <main class="flex-1">
+    <main class="flex-1 mt-5">
       <%= form_with model: @checklist do |f| %>
         <div class="border border-gray-300 p-4">
           <h3 class="font-bold flex justify-center mb-3">オススメのアイテム</h3>


### PR DESCRIPTION
済

- タイムライン：discarded_atした日ごとにdeviderで区切る discarded_atした時間だけ左サイドに配置する
[![Image from Gyazo](https://i.gyazo.com/ccf941b8eb6082c5e1b73cfbdec1fc90.png)](https://gyazo.com/ccf941b8eb6082c5e1b73cfbdec1fc90)

- サインアップ時：ユーザーネームを任意で登録できる
→アカウント編集せずユーザーネームが登録されていない場合、タイムラインに表示するユーザーネームがnilになる可能性を減らすため