### PR TITLE
improve: トップページ

### DIFF
--- a/app/views/static_pages/_guide.html.erb
+++ b/app/views/static_pages/_guide.html.erb
@@ -31,6 +31,7 @@
           <p>断捨離したことをタイムライン上でシェアすることができます</p>
           <p>他の人の断捨離も見られるので、「私もやってみよう」と前向きに。</p> 
           <p class="text-sm text-gray-500">※お洋服の詳細情報は公開されません</p>
+          <p><%= link_to "みんなの断捨離タイムラインをのぞいてみる", discarded_cloths_path,  class: "btn btn-outline btn-secondary mt-2" %></p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
トップページ/使い方ガイド/guide#2にて「みんなの断捨離タイムライン」へのボタンとパスを追加
理由：未ログイン閲覧可能ページのため未ログインユーザーへサービス利用を促すため