### PR TITLE
add: 断捨離するボタン押下後の確認画面

### DIFF
--- a/app/controllers/cloths_controller.rb
+++ b/app/controllers/cloths_controller.rb
@@ -95,10 +95,10 @@ class ClothsController < ApplicationController
     category_ids << params[:parent_id] if params[:parent_id].present?
     category_ids << params[:child_id] if params[:child_id].present?
 
-    params.require(:cloth).permit( :image_file, :image_file_cache, :brand, :body, :purchase_date, :price, { season_ids: [] }).merge(category_ids: category_ids) # モデル名_ids: []複数のidを配列で受け取る
+    params.require(:cloth).permit(:image_file, :image_file_cache, :brand, :body, :purchase_date, :price, { season_ids: [] }).merge(category_ids: category_ids) # モデル名_ids: []複数のidを配列で受け取る
   end
 
   def discard_params
-    params.require(:cloth).permit( :title )
+    params.require(:cloth).permit(:title)
   end
 end

--- a/app/controllers/cloths_controller.rb
+++ b/app/controllers/cloths_controller.rb
@@ -1,6 +1,6 @@
 class ClothsController < ApplicationController
   before_action :authenticate_user!, except: %i[ discarded ]
-  before_action :set_cloth, only: %i[ show update destroy ]
+  before_action :set_cloth, only: %i[ show update destroy confirm_discard discard]
   after_action :check_season, only: %i[ create ]
 
   def index
@@ -26,6 +26,7 @@ class ClothsController < ApplicationController
 
   def create
     @cloth = current_user.cloths.new(cloth_params)
+    @cloth.title ||= "もっと捨てたい"
 
     if @cloth.save
     else
@@ -56,10 +57,16 @@ class ClothsController < ApplicationController
     @favorite_cloths = current_user.favorite_cloths.page(params[:page]).order(created_at: :desc)
   end
 
+  def confirm_discard
+  end
+
   def discard
-    @cloth = current_user.cloths.find(params[:id])
-    @cloth.discard!
-    redirect_to cloths_path, notice: "みんなの断捨離タイムラインに移動しました", status: :see_other
+    if @cloth.update(discard_params)
+      @cloth.discard!
+      redirect_to cloth_path, notice: "みんなの断捨離タイムラインに移動しました", status: :see_other
+    else
+      render :confirm_discard, status: :unprocessable_entity
+    end
   end
 
   def discarded
@@ -88,6 +95,10 @@ class ClothsController < ApplicationController
     category_ids << params[:parent_id] if params[:parent_id].present?
     category_ids << params[:child_id] if params[:child_id].present?
 
-    params.require(:cloth).permit(:image_file, :image_file_cache, :brand, :body, :purchase_date, :price, { season_ids: [] },).merge(category_ids: category_ids) # モデル名_ids: []複数のidを配列で受け取る
+    params.require(:cloth).permit( :image_file, :image_file_cache, :brand, :body, :purchase_date, :price, { season_ids: [] }).merge(category_ids: category_ids) # モデル名_ids: []複数のidを配列で受け取る
+  end
+
+  def discard_params
+    params.require(:cloth).permit( :title )
   end
 end

--- a/app/models/cloth.rb
+++ b/app/models/cloth.rb
@@ -8,6 +8,7 @@ class Cloth < ApplicationRecord
   validates :price, presence: true, allow_nil: true, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 9_999_999 }
   validates :season_ids, presence: true
   validates :category_ids, presence: true
+  validates :title, presence: true
 
   belongs_to :user
 

--- a/app/views/cloths/_discard_form.html.erb
+++ b/app/views/cloths/_discard_form.html.erb
@@ -1,0 +1,21 @@
+<div class="max-w-md mx-auto space-y-6">
+  <div class="text-center">
+    <div class="font-bold">確認画面</div>
+    <div class="divider"></div>
+
+    <p>公開される画像</p>
+    <%= image_tag cloth.image_file_url, class: "max-w-[250px] max-h-[200px] mx-auto rounded-md" %>
+  </div>
+
+  <%= form_with model: @cloth, url: discard_cloth_path(@cloth), class: "space-y-4" do |form| %>
+    <%= render "shared/error_messages", object: form.object %>
+
+    <div class="form-control">
+      <%= form.text_field :title, placeholder: "お気持ち", class: "input input-bordered w-full" %>
+    </div>
+
+    <div class="text-center">
+      <%= form.submit "確定する", data: { confirm: "一覧画面から消え、他のユーザーも見ることができるようになります", turbo_confirm: "一覧画面から消え、他のユーザーも見ることができるようになります" }, class: "btn btn-primary px-6 py-2" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/cloths/confirm_discard.html.erb
+++ b/app/views/cloths/confirm_discard.html.erb
@@ -1,0 +1,10 @@
+<turbo-frame id="modal">
+  <dialog data-controller="modal" data-modal-target="dialog" 
+    data-action="turbo:submit-end->modal#closeOnSubmit click->modal#backdropClick" id="modal_dialog" class="modal" open>
+    <div class="modal-box">
+
+    <%= render "discard_form", cloth: @cloth %>
+    
+    <form method="dialog" class="modal-backdrop"></form>
+  </dialog>
+</turbo-frame>

--- a/app/views/cloths/discarded.html.erb
+++ b/app/views/cloths/discarded.html.erb
@@ -20,29 +20,30 @@
             <div class="timeline-end timeline-box flex items-center space-x-4 p-4">
               <div class="flex flex-col">
                 <div class="flex items-center gap-3">
-                <div class="avatar">
-                  <div class="w-10 rounded-full">
-                    <%= image_tag cloth.user.profile_image_url %>
-                  </div>
-                </div>
-                <div class="flex-1">
-                  <p class="text-sm font-semibold"><%= cloth.user.username %> さんが断捨離しました！</p>
-                </div>
-                </div>
+                  <div class="flex-1">
+                    <div class="avatar">
+                      <div class="w-10 rounded-full">
+                        <%= image_tag cloth.user.profile_image_url %>
+                      </div>
+                    </div>
+                      <p class="text-sm font-semibold"><%= cloth.user.username %> さんが断捨離しました！</p>
+                      <%= image_tag cloth.image_file_url, class: "max-w-[150px] max-h-[100px] mx-auto rounded-md" %>
+                      <p class="text-sm text-center"><%= cloth.title %></p>
+                    </div>
 
-                <% if user_signed_in? && cloth.user == current_user %>
-                  <div class="divider"></div>
-                  <div class="flex flex-wrap items-center justify-center space-x-2">
-                    <%= link_to "https://twitter.com/intent/tweet?text=well断で断捨離した！%0A&url=https://welldoneshari.com/cloths/discarded", target: "_blank", rel: "noopener noreferrer" do %>
-                      <button class="btn btn-circle fa-brands fa-square-x-twitter fa-xl" style="color: #293454;"></button>
-                    <% end %>
+                    <% if user_signed_in? && cloth.user == current_user %>
+                      <div class="flex flex-wrap items-center justify-center space-x-2">
+                        <%= link_to "https://twitter.com/intent/tweet?text=well断で断捨離した！%0A&url=https://welldoneshari.com/cloths/discarded", target: "_blank", rel: "noopener noreferrer" do %>
+                          <button class="btn btn-circle fa-brands fa-square-x-twitter fa-xl" style="color: #293454;"></button>
+                        <% end %>
 
-                    <%= link_to destroy_discarded_cloth_path(cloth, cloth.id, id: cloth), 
-                                data: { turbo_method: :delete, confirm: "本当に削除しますか？" } do %>
-                      <button class="btn btn-circle fa-solid fa-trash fa-lg" style="color: #293454;"></button>
+                        <%= link_to destroy_discarded_cloth_path(cloth, cloth.id, id: cloth), 
+                                    data: { turbo_method: :delete, confirm: "本当に削除しますか？" } do %>
+                          <button class="btn btn-circle fa-solid fa-trash fa-lg" style="color: #293454;"></button>
+                        <% end %>
+                      </div>
                     <% end %>
                   </div>
-                <% end %>
               </div>
             </div>
             <hr />

--- a/app/views/cloths/show.html.erb
+++ b/app/views/cloths/show.html.erb
@@ -16,7 +16,11 @@
     </div>
 
     <%= render @cloth %>
-    
-    <%= button_to  "断捨離する", discard_cloth_path(@cloth), data: { confirm: "断捨離しますか？一覧画面から消え、他のユーザーも見ることができるようになります", turbo_confirm:"断捨離しますか？一覧画面から消え、他のユーザーも見ることができるようになります"}, class: "btn btn-block btn-info" %>
+        
+    <div class="tooltip" data-tip="確認画面が表示されます">
+      <%= link_to confirm_discard_cloth_path(@cloth), data: { action: "modal#open", turbo_frame: "modal" }, class: "btn btn-block btn-outline btn-info" do %>
+      断捨離する
+      <% end %>
+    </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,8 +14,9 @@ Rails.application.routes.draw do
       get :discarded
     end
     member do # idを伴うパス
-      post :discard
-      delete "destroy_discarded/:id", to: "cloths#destroy_discarded", as: :destroy_discarded
+      get :confirm_discard
+      patch :discard
+      delete :destroy_discarded
     end
   end
 

--- a/db/migrate/20250512133721_add_title_to_cloths.rb
+++ b/db/migrate/20250512133721_add_title_to_cloths.rb
@@ -1,0 +1,5 @@
+class AddTitleToCloths < ActiveRecord::Migration[7.2]
+  def change
+    add_column :cloths, :title, :string, null: true
+  end
+end

--- a/db/migrate/20250512134802_change_title_to_not_null_in_cloths.rb
+++ b/db/migrate/20250512134802_change_title_to_not_null_in_cloths.rb
@@ -1,0 +1,5 @@
+class ChangeTitleToNotNullInCloths < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :cloths, :title, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_02_100348) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_12_134802) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -59,6 +59,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_02_100348) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "discarded_at"
+    t.string "title", null: false
     t.index ["discarded_at"], name: "index_cloths_on_discarded_at"
     t.index ["user_id"], name: "index_cloths_on_user_id"
   end


### PR DESCRIPTION
動的OGPを実装するため、断捨離ボタンを押下後の確認画面を実装
理由：できる限り公開する情報を絞りつつ、動的OGPを実装するための個別要素を設けるため

済

- 公開用タイトル(一言メッセージ)を作成するためclothテーブルにtitleカラムを追加
- 確認フォームにのみtitleカラムをストロングパラメータとして使用するための`discard_params`を追加
- 確認画面でtitleが入力、フォームに送信される
- 「これが公開されるよ！！」というアナウンス的な意図をもって、cloth.image_fileを確認画面で表示
- タイムラインにてtitleとimage_fileを表示

未

- cloth_paramsには:title含んでないのに#createするときtitleに対してバリデーションエラーが発生する
#discardではバリデーションエラー自体出ない
どこで間違ってるんだ！！！
#createできないと不便なので応急処置として仮タイトル指定した

``` 
def create
    @cloth = current_user.cloths.new(cloth_params)
    @cloth.title ||= "もっと捨てたい"

def cloth_params
    params.require(:cloth).permit(:image_file, :image_file_cache, :brand, :body, :purchase_date, :price, { season_ids: [] }).merge(category_ids: category_ids) # モデル名_ids: []複数のidを配列で受け取る
  end

  def discard_params
    params.require(:cloth).permit(:title)
  end
```
[![Image from Gyazo](https://i.gyazo.com/c42f929fc43f38076b51fc0777791814.png)](https://gyazo.com/c42f929fc43f38076b51fc0777791814)
